### PR TITLE
管理者ログイン後の施設未設定セットアップ導線を追加

### DIFF
--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
   include ActionController::RequestForgeryProtection
+  include Devise::Controllers::Helpers
 
   protect_from_forgery with: :null_session
 
@@ -29,6 +30,17 @@ class ApplicationController < ActionController::API
     return nil unless payload.is_a?(Hash)
 
     Staff.find_by(id: payload['staff_id'] || payload[:staff_id], confirmed_at: nil)
+  end
+
+  def serialize_current_staff(staff)
+    {
+      id: staff.id,
+      name: staff.name,
+      email: staff.email,
+      role: staff.role,
+      facility_id: staff.facility_id,
+      needs_facility_setup: staff.admin? && staff.facility_id.blank?
+    }
   end
 
   def preflight

--- a/api/app/controllers/facilities_controller.rb
+++ b/api/app/controllers/facilities_controller.rb
@@ -1,0 +1,36 @@
+class FacilitiesController < ApplicationController
+  before_action :authenticate_staff!
+  skip_before_action :verify_authenticity_token
+
+  def create
+    facility = Facilities::CreateForAdmin.call(
+      staff: current_staff,
+      facility_params: facility_params.to_h.symbolize_keys
+    )
+
+    render json: { facility_id: facility.id, staff: serialize_current_staff(current_staff.reload) }, status: :created
+  rescue Facilities::CreateForAdmin::NotAllowedError
+    render json: { errors: ['施設を作成できるのは管理者のみです'] }, status: :forbidden
+  rescue Facilities::CreateForAdmin::AlreadyLinkedError
+    render json: { errors: ['施設はすでに設定されています'] }, status: :unprocessable_entity
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  private
+
+  def facility_params
+    params.require(:facility).permit(
+      :name,
+      :phone,
+      :address_prefecture,
+      :address_line,
+      :postal_code,
+      :description,
+      :access_info,
+      :base_capacity,
+      :base_price,
+      :status
+    )
+  end
+end

--- a/api/app/controllers/staffs/me_controller.rb
+++ b/api/app/controllers/staffs/me_controller.rb
@@ -1,0 +1,7 @@
+class Staffs::MeController < ApplicationController
+  before_action :authenticate_staff!
+
+  def show
+    render json: { staff: serialize_current_staff(current_staff) }, status: :ok
+  end
+end

--- a/api/app/controllers/staffs/sessions_controller.rb
+++ b/api/app/controllers/staffs/sessions_controller.rb
@@ -1,0 +1,21 @@
+class Staffs::SessionsController < Devise::SessionsController
+  respond_to :json
+  protect_from_forgery with: :null_session
+  skip_before_action :verify_authenticity_token
+
+  def destroy
+    signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+    status = signed_out ? :ok : :unauthorized
+
+    render json: { message: 'signed_out' }, status: status
+  end
+
+  private
+
+  def respond_with(resource, _opts = {})
+    render json: {
+      message: 'signed_in',
+      staff: serialize_current_staff(resource)
+    }, status: :ok
+  end
+end

--- a/api/app/services/facilities/create_for_admin.rb
+++ b/api/app/services/facilities/create_for_admin.rb
@@ -1,0 +1,32 @@
+module Facilities
+  class CreateForAdmin
+    class NotAllowedError < StandardError; end
+    class AlreadyLinkedError < StandardError; end
+
+    def self.call(staff:, facility_params:)
+      new(staff:, facility_params:).call
+    end
+
+    def initialize(staff:, facility_params:)
+      @staff = staff
+      @facility_params = facility_params
+    end
+
+    def call
+      raise NotAllowedError unless staff.admin?
+
+      Staff.transaction do
+        staff.lock!
+        raise AlreadyLinkedError if staff.facility_id.present?
+
+        facility = Facility.create!(facility_params)
+        staff.update!(facility:)
+        facility
+      end
+    end
+
+    private
+
+    attr_reader :staff, :facility_params
+  end
+end

--- a/api/config/environments/test.rb
+++ b/api/config/environments/test.rb
@@ -52,6 +52,7 @@ Rails.application.configure do
 
   # Devise mailer host for tests
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.hosts.clear
 
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -2,14 +2,18 @@ Rails.application.routes.draw do
   scope '/api/v1', defaults: { format: :json } do
     devise_for :staffs,
                controllers: {
+                 sessions: 'staffs/sessions',
                  registrations: 'staffs/registrations',
                  confirmations: 'staffs/confirmations'
                },
-               skip: [:sessions, :passwords]
+               skip: [:passwords]
 
     devise_scope :staff do
       get 'staffs/confirmation/pending', to: 'staffs/confirmations#pending'
     end
+
+    get 'staffs/me', to: 'staffs/me#show'
+    resources :facilities, only: [:create]
 
     match '*path', to: 'application#preflight', via: :options
   end

--- a/api/spec/requests/staff_facility_setup_spec.rb
+++ b/api/spec/requests/staff_facility_setup_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Staff facility setup', type: :request do
+  let(:headers) do
+    {
+      'ACCEPT' => 'application/json',
+      'CONTENT_TYPE' => 'application/json'
+    }
+  end
+
+  let(:facility_params) do
+    {
+      name: 'New Sauna',
+      address_prefecture: 'Tokyo',
+      address_line: 'Meguro 1-2-3',
+      description: 'fresh',
+      base_capacity: 10,
+      base_price: 3500,
+      status: 'under_review'
+    }
+  end
+
+  describe 'POST /api/v1/staffs/sign_in' do
+    it 'returns needs_facility_setup for admin without facility' do
+      staff = Staff.create!(
+        name: 'Admin',
+        email: 'admin-no-facility@example.com',
+        password: 'password123',
+        password_confirmation: 'password123',
+        confirmed_at: Time.current
+      )
+
+      post '/api/v1/staffs/sign_in', params: {
+        staff: {
+          email: staff.email,
+          password: 'password123'
+        }
+      }.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig('staff', 'needs_facility_setup')).to be(true)
+      expect(response.parsed_body.dig('staff', 'facility_id')).to be_nil
+    end
+
+    it 'does not require setup for admin with facility' do
+      facility = Facility.create!(
+        name: 'Existing Sauna',
+        address_prefecture: 'Tokyo',
+        address_line: 'Shibuya 1-1-1',
+        description: 'desc',
+        base_capacity: 5,
+        base_price: 2000,
+        status: 'active'
+      )
+      staff = Staff.create!(
+        name: 'Admin',
+        email: 'admin-with-facility@example.com',
+        password: 'password123',
+        password_confirmation: 'password123',
+        facility: facility,
+        confirmed_at: Time.current
+      )
+
+      post '/api/v1/staffs/sign_in', params: {
+        staff: {
+          email: staff.email,
+          password: 'password123'
+        }
+      }.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig('staff', 'needs_facility_setup')).to be(false)
+      expect(response.parsed_body.dig('staff', 'facility_id')).to eq(facility.id)
+    end
+  end
+
+  describe 'GET /api/v1/staffs/me' do
+    it 'returns the current staff with facility setup state' do
+      staff = Staff.create!(
+        name: 'Admin',
+        email: 'admin-me@example.com',
+        password: 'password123',
+        password_confirmation: 'password123',
+        confirmed_at: Time.current
+      )
+
+      post '/api/v1/staffs/sign_in', params: {
+        staff: {
+          email: staff.email,
+          password: 'password123'
+        }
+      }.to_json, headers: headers
+
+      get '/api/v1/staffs/me', headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig('staff', 'email')).to eq(staff.email)
+      expect(response.parsed_body.dig('staff', 'needs_facility_setup')).to be(true)
+    end
+
+    it 'returns unauthorized when not signed in' do
+      get '/api/v1/staffs/me', headers: headers
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /api/v1/facilities' do
+    it 'creates a facility and links it to the signed-in admin' do
+      staff = Staff.create!(
+        name: 'Admin',
+        email: 'admin-create-facility@example.com',
+        password: 'password123',
+        password_confirmation: 'password123',
+        confirmed_at: Time.current
+      )
+
+      post '/api/v1/staffs/sign_in', params: {
+        staff: {
+          email: staff.email,
+          password: 'password123'
+        }
+      }.to_json, headers: headers
+
+      expect do
+        post '/api/v1/facilities', params: { facility: facility_params }.to_json, headers: headers
+      end.to change(Facility, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['facility_id']).to be_present
+      expect(response.parsed_body.dig('staff', 'facility_id')).to eq(staff.reload.facility_id)
+      expect(response.parsed_body.dig('staff', 'needs_facility_setup')).to be(false)
+    end
+
+    it 'rejects facility creation for non-admin staff' do
+      staff = Staff.create!(
+        name: 'Staff',
+        email: 'staff-create-facility@example.com',
+        password: 'password123',
+        password_confirmation: 'password123',
+        role: :staff,
+        confirmed_at: Time.current
+      )
+
+      post '/api/v1/staffs/sign_in', params: {
+        staff: {
+          email: staff.email,
+          password: 'password123'
+        }
+      }.to_json, headers: headers
+
+      post '/api/v1/facilities', params: { facility: facility_params }.to_json, headers: headers
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'rejects facility creation when the admin already has a facility' do
+      facility = Facility.create!(
+        name: 'Existing Sauna',
+        address_prefecture: 'Tokyo',
+        address_line: 'Shibuya 1-1-1',
+        description: 'desc',
+        base_capacity: 5,
+        base_price: 2000,
+        status: 'active'
+      )
+      staff = Staff.create!(
+        name: 'Admin',
+        email: 'admin-existing-facility@example.com',
+        password: 'password123',
+        password_confirmation: 'password123',
+        facility: facility,
+        confirmed_at: Time.current
+      )
+
+      post '/api/v1/staffs/sign_in', params: {
+        staff: {
+          email: staff.email,
+          password: 'password123'
+        }
+      }.to_json, headers: headers
+
+      post '/api/v1/facilities', params: { facility: facility_params }.to_json, headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,33 +1,59 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { StaffRouteGuard } from './components/staff/StaffRouteGuard';
 import { MainLayout } from './layouts/MainLayout';
 import { Home } from './pages/Home';
 import { StaffSignup } from './pages/StaffSignup';
 import { StaffSignupSent } from './pages/StaffSignupSent';
 import { BlankLayout } from './layouts/BlankLayout';
+import { StaffLogin } from './pages/StaffLogin';
+import { StaffFacilitySetup } from './pages/StaffFacilitySetup';
 
 export const App = () => {
   return (
     <BrowserRouter>
       <Routes>
         <Route
-          path="/staff/signup/*"
+          path="/staff/signup"
           element={
             <BlankLayout>
-              <Routes>
-                <Route path="" element={<StaffSignup />} />
-                <Route path="sent" element={<StaffSignupSent />} />
-              </Routes>
+              <StaffSignup />
             </BlankLayout>
           }
         />
         <Route
-          path="/*"
+          path="/staff/signup/sent"
           element={
-            <MainLayout>
-              <Routes>
-                <Route path="/" element={<Home />} />
-              </Routes>
-            </MainLayout>
+            <BlankLayout>
+              <StaffSignupSent />
+            </BlankLayout>
+          }
+        />
+        <Route
+          path="/staff/login"
+          element={
+            <BlankLayout>
+              <StaffLogin />
+            </BlankLayout>
+          }
+        />
+        <Route
+          path="/staff/facility/setup"
+          element={
+            <StaffRouteGuard requireFacilitySetup>
+              <BlankLayout>
+                <StaffFacilitySetup />
+              </BlankLayout>
+            </StaffRouteGuard>
+          }
+        />
+        <Route
+          path="/"
+          element={
+            <StaffRouteGuard>
+              <MainLayout>
+                <Home />
+              </MainLayout>
+            </StaffRouteGuard>
           }
         />
       </Routes>

--- a/frontend/src/api/staff.ts
+++ b/frontend/src/api/staff.ts
@@ -5,10 +5,58 @@ export type StaffSignupParams = {
   password_confirmation: string;
 };
 
+export type StaffLoginParams = {
+  email: string;
+  password: string;
+};
+
 export type StaffSignupResponse = {
   message: string;
   email: string;
 };
+
+export type CurrentStaff = {
+  id: number;
+  name: string;
+  email: string;
+  role: 'admin' | 'staff';
+  facility_id: number | null;
+  needs_facility_setup: boolean;
+};
+
+export type StaffSessionResponse = {
+  message: string;
+  staff: CurrentStaff;
+};
+
+export type FacilityCreateParams = {
+  name: string;
+  phone?: string;
+  address_prefecture: string;
+  address_line: string;
+  postal_code?: string;
+  description?: string;
+  access_info?: string;
+  base_capacity: number;
+  base_price: number;
+  status: 'active' | 'inactive' | 'under_review';
+};
+
+class StaffApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'StaffApiError';
+    this.status = status;
+  }
+}
+
+async function parseError(res: Response, fallbackMessage: string) {
+  const body = await res.json().catch(() => ({}));
+  const message = body.errors?.join('\n') || fallbackMessage;
+  return new StaffApiError(message, res.status);
+}
 
 export async function signupStaff(params: StaffSignupParams) {
   const res = await fetch(`${import.meta.env.VITE_API_URL}/staffs`, {
@@ -22,11 +70,62 @@ export async function signupStaff(params: StaffSignupParams) {
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.errors?.join('\n') || 'サインアップに失敗しました');
+    throw await parseError(res, 'サインアップに失敗しました');
   }
 
   return res.json() as Promise<StaffSignupResponse>;
+}
+
+export async function loginStaff(params: StaffLoginParams) {
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/staffs/sign_in`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ staff: params }),
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    throw await parseError(res, 'ログインに失敗しました');
+  }
+
+  return res.json() as Promise<StaffSessionResponse>;
+}
+
+export async function fetchCurrentStaff() {
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/staffs/me`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    throw await parseError(res, 'スタッフ情報の取得に失敗しました');
+  }
+
+  return res.json() as Promise<{ staff: CurrentStaff }>;
+}
+
+export async function createFacility(params: FacilityCreateParams) {
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/facilities`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ facility: params }),
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    throw await parseError(res, '施設情報の作成に失敗しました');
+  }
+
+  return res.json() as Promise<{ facility_id: number; staff: CurrentStaff }>;
 }
 
 export async function fetchPendingStaffConfirmation() {
@@ -39,8 +138,7 @@ export async function fetchPendingStaffConfirmation() {
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.errors?.join('\n') || '確認待ち情報の取得に失敗しました');
+    throw await parseError(res, '確認待ち情報の取得に失敗しました');
   }
 
   return res.json() as Promise<{ email: string }>;
@@ -57,9 +155,10 @@ export async function resendStaffConfirmation() {
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.errors?.join('\n') || '確認メールの再送に失敗しました');
+    throw await parseError(res, '確認メールの再送に失敗しました');
   }
 
   return res.json() as Promise<StaffSignupResponse>;
 }
+
+export { StaffApiError };

--- a/frontend/src/components/staff/FacilitySetupForm.tsx
+++ b/frontend/src/components/staff/FacilitySetupForm.tsx
@@ -1,0 +1,137 @@
+import { useFacilitySetup } from '../../hooks/useFacilitySetup';
+import { ErrorAlert } from '../shared/ErrorAlert';
+
+type InputFieldProps = {
+  label: string;
+  value: string;
+  type?: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+};
+
+const InputField = ({ label, value, type = 'text', placeholder, onChange, required = false }: InputFieldProps) => (
+  <div>
+    <label className="form-label">
+      {label}
+      {required ? ' *' : ''}
+    </label>
+    <input
+      className="form-control signup"
+      type={type}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  </div>
+);
+
+type TextAreaFieldProps = {
+  label: string;
+  value: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+};
+
+const TextAreaField = ({ label, value, placeholder, onChange }: TextAreaFieldProps) => (
+  <div>
+    <label className="form-label">{label}</label>
+    <textarea
+      className="form-control"
+      rows={4}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  </div>
+);
+
+export const FacilitySetupForm = () => {
+  const { state, setField, submit } = useFacilitySetup();
+
+  return (
+    <div className="glass-panel w-100 mx-3 mx-lg-5 p-4 p-lg-4">
+      <div className="mb-4">
+        <div className="small text-uppercase fw-semibold text-secondary mb-2">Facility Setup</div>
+        <h2 className="signup-title mb-2">施設情報の初期設定</h2>
+        <p className="signup-subtitle mb-0">
+          管理者アカウントに紐づける最初の施設情報を入力してください。
+        </p>
+      </div>
+
+      <form className="d-flex flex-column gap-3" onSubmit={submit}>
+        {state.error && <ErrorAlert message={state.error} />}
+        <InputField
+          label="施設名"
+          value={state.name}
+          placeholder="Sauna Station"
+          onChange={(value) => setField('name', value)}
+          required
+        />
+        <InputField
+          label="都道府県"
+          value={state.addressPrefecture}
+          placeholder="東京都"
+          onChange={(value) => setField('addressPrefecture', value)}
+          required
+        />
+        <InputField
+          label="住所"
+          value={state.addressLine}
+          placeholder="渋谷区神南 1-2-3"
+          onChange={(value) => setField('addressLine', value)}
+          required
+        />
+        <div className="row g-3">
+          <div className="col-md-6">
+            <InputField
+              label="定員"
+              value={state.baseCapacity}
+              type="number"
+              placeholder="10"
+              onChange={(value) => setField('baseCapacity', value)}
+              required
+            />
+          </div>
+          <div className="col-md-6">
+            <InputField
+              label="基本料金"
+              value={state.basePrice}
+              type="number"
+              placeholder="3000"
+              onChange={(value) => setField('basePrice', value)}
+              required
+            />
+          </div>
+        </div>
+        <InputField
+          label="電話番号"
+          value={state.phone}
+          placeholder="0312345678"
+          onChange={(value) => setField('phone', value)}
+        />
+        <InputField
+          label="郵便番号"
+          value={state.postalCode}
+          placeholder="1500041"
+          onChange={(value) => setField('postalCode', value)}
+        />
+        <TextAreaField
+          label="施設説明"
+          value={state.description}
+          placeholder="施設の特徴やサービス内容"
+          onChange={(value) => setField('description', value)}
+        />
+        <TextAreaField
+          label="アクセス情報"
+          value={state.accessInfo}
+          placeholder="最寄駅からの導線や駐車場情報"
+          onChange={(value) => setField('accessInfo', value)}
+        />
+        <button className="btn btn-gradient w-100 py-2" type="submit" disabled={state.loading}>
+          {state.loading ? '作成中...' : '施設を作成する'}
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/components/staff/StaffLoginForm.tsx
+++ b/frontend/src/components/staff/StaffLoginForm.tsx
@@ -1,0 +1,66 @@
+import { Link } from 'react-router-dom';
+import { useStaffLogin } from '../../hooks/useStaffLogin';
+import { ErrorAlert } from '../shared/ErrorAlert';
+
+type InputFieldProps = {
+  label: string;
+  type?: string;
+  value: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+};
+
+const InputField = ({ label, type = 'text', value, placeholder, onChange }: InputFieldProps) => (
+  <div>
+    <label className="form-label">{label}</label>
+    <input
+      className="form-control signup"
+      type={type}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  </div>
+);
+
+export const StaffLoginForm = () => {
+  const { state, setField, submit } = useStaffLogin();
+
+  return (
+    <div className="glass-panel w-100 mx-3 mx-lg-5 p-4 p-lg-4">
+      <div className="mb-4">
+        <div className="small text-uppercase fw-semibold text-secondary mb-2">Staff Login</div>
+        <h2 className="signup-title mb-2">管理者ログイン</h2>
+        <p className="signup-subtitle mb-0">ログイン後、施設未設定の管理者は施設セットアップに進みます。</p>
+      </div>
+
+      <form className="d-flex flex-column gap-3" onSubmit={submit}>
+        {state.error && <ErrorAlert message={state.error} />}
+        <InputField
+          label="メールアドレス"
+          type="email"
+          value={state.email}
+          placeholder="admin@example.com"
+          onChange={(value) => setField('email', value)}
+        />
+        <InputField
+          label="パスワード"
+          type="password"
+          value={state.password}
+          placeholder="パスワードを入力してください"
+          onChange={(value) => setField('password', value)}
+        />
+        <button className="btn btn-gradient w-100 py-2" type="submit" disabled={state.loading}>
+          {state.loading ? 'ログイン中...' : 'ログインする'}
+        </button>
+      </form>
+
+      <div className="text-center text-secondary pt-3">
+        アカウント未登録ですか？{' '}
+        <Link className="signup-footer-link fw-semibold" to="/staff/signup">
+          新規登録はこちら
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/staff/StaffRouteGuard.tsx
+++ b/frontend/src/components/staff/StaffRouteGuard.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import { useStaffRouteGuard } from '../../hooks/useStaffRouteGuard';
+
+type StaffRouteGuardProps = {
+  children: ReactNode;
+  requireFacilitySetup?: boolean;
+};
+
+export const StaffRouteGuard = ({ children, requireFacilitySetup = false }: StaffRouteGuardProps) => {
+  const { isLoading, isReady } = useStaffRouteGuard({ requireFacilitySetup });
+
+  if (isLoading) {
+    return <div className="d-flex align-items-center justify-content-center min-vh-100">Loading...</div>;
+  }
+
+  if (!isReady) {
+    return null;
+  }
+
+  return <>{children}</>;
+};

--- a/frontend/src/components/staff/StaffSignupForm.tsx
+++ b/frontend/src/components/staff/StaffSignupForm.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { useStaffSignup } from '../../hooks/useStaffSignup';
 import { ErrorAlert } from '../shared/ErrorAlert';
 
@@ -13,7 +14,7 @@ const InputField = ({ label, type = 'text', value, placeholder, onChange }: Inpu
   <div>
     <label className="form-label">{label}</label>
     <input
-      className="form-control"
+      className="form-control signup"
       type={type}
       value={value}
       onChange={(e) => onChange(e.target.value)}
@@ -63,9 +64,9 @@ export const StaffSignupForm = () => {
 
       <div className="text-center text-secondary pt-3">
         すでにアカウントをお持ちですか？{' '}
-        <a className="signup-footer-link fw-semibold" href="/staff/login">
+        <Link className="signup-footer-link fw-semibold" to="/staff/login">
           ログインはこちら
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/hooks/useFacilitySetup.ts
+++ b/frontend/src/hooks/useFacilitySetup.ts
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createFacility } from '../api/staff';
+
+type Field =
+  | 'name'
+  | 'phone'
+  | 'addressPrefecture'
+  | 'addressLine'
+  | 'postalCode'
+  | 'description'
+  | 'accessInfo'
+  | 'baseCapacity'
+  | 'basePrice';
+
+export const useFacilitySetup = () => {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    name: '',
+    phone: '',
+    addressPrefecture: '',
+    addressLine: '',
+    postalCode: '',
+    description: '',
+    accessInfo: '',
+    baseCapacity: '10',
+    basePrice: '3000',
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setField = (field: Field, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!form.name || !form.addressPrefecture || !form.addressLine || !form.baseCapacity || !form.basePrice) {
+      setError('必須項目を入力してください');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await createFacility({
+        name: form.name,
+        phone: form.phone || undefined,
+        address_prefecture: form.addressPrefecture,
+        address_line: form.addressLine,
+        postal_code: form.postalCode || undefined,
+        description: form.description || undefined,
+        access_info: form.accessInfo || undefined,
+        base_capacity: Number(form.baseCapacity),
+        base_price: Number(form.basePrice),
+        status: 'under_review',
+      });
+      navigate('/', { replace: true });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '施設情報の作成に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    state: {
+      ...form,
+      loading,
+      error,
+    },
+    setField,
+    submit,
+  };
+};

--- a/frontend/src/hooks/useStaffLogin.ts
+++ b/frontend/src/hooks/useStaffLogin.ts
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { loginStaff } from '../api/staff';
+
+type Field = 'email' | 'password';
+
+export const useStaffLogin = () => {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    email: '',
+    password: '',
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setField = (field: Field, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!form.email || !form.password) {
+      setError('メールアドレスとパスワードを入力してください');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await loginStaff(form);
+      navigate(response.staff.needs_facility_setup ? '/staff/facility/setup' : '/', { replace: true });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'ログインに失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    state: {
+      ...form,
+      loading,
+      error,
+    },
+    setField,
+    submit,
+  };
+};

--- a/frontend/src/hooks/useStaffRouteGuard.ts
+++ b/frontend/src/hooks/useStaffRouteGuard.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchCurrentStaff, StaffApiError, type CurrentStaff } from '../api/staff';
+
+type GuardState = {
+  isLoading: boolean;
+  isReady: boolean;
+  staff: CurrentStaff | null;
+};
+
+type GuardOptions = {
+  requireFacilitySetup?: boolean;
+};
+
+export const useStaffRouteGuard = (options: GuardOptions = {}) => {
+  const navigate = useNavigate();
+  const [state, setState] = useState<GuardState>({
+    isLoading: true,
+    isReady: false,
+    staff: null,
+  });
+
+  useEffect(() => {
+    let isActive = true;
+
+    const guard = async () => {
+      try {
+        const response = await fetchCurrentStaff();
+        const staff = response.staff;
+
+        if (options.requireFacilitySetup) {
+          if (!staff.needs_facility_setup) {
+            navigate('/', { replace: true });
+            return;
+          }
+        } else if (staff.needs_facility_setup) {
+          navigate('/staff/facility/setup', { replace: true });
+          return;
+        }
+
+        if (isActive) {
+          setState({
+            isLoading: false,
+            isReady: true,
+            staff,
+          });
+        }
+      } catch (err) {
+        if (err instanceof StaffApiError && err.status === 401) {
+          navigate('/staff/login', { replace: true });
+          return;
+        }
+
+        if (isActive) {
+          setState({
+            isLoading: false,
+            isReady: false,
+            staff: null,
+          });
+        }
+      }
+    };
+
+    guard();
+
+    return () => {
+      isActive = false;
+    };
+  }, [navigate, options.requireFacilitySetup]);
+
+  return state;
+};

--- a/frontend/src/hooks/useStaffSignup.ts
+++ b/frontend/src/hooks/useStaffSignup.ts
@@ -42,8 +42,8 @@ export const useStaffSignup = () => {
         password_confirmation: passwordConfirmation,
       });
       navigate('/staff/signup/sent');
-    } catch (err: any) {
-      setError(err.message ?? 'サインアップに失敗しました');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'サインアップに失敗しました');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/hooks/useStaffSignupSent.ts
+++ b/frontend/src/hooks/useStaffSignupSent.ts
@@ -14,8 +14,8 @@ export const useStaffSignupSent = () => {
         const response = await fetchPendingStaffConfirmation();
         setEmail(response.email);
         setStatus('idle');
-      } catch (err: any) {
-        setError(err.message ?? '確認待ち情報の取得に失敗しました');
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : '確認待ち情報の取得に失敗しました');
         setStatus('missing');
       }
     };
@@ -32,8 +32,8 @@ export const useStaffSignupSent = () => {
       const response = await resendStaffConfirmation();
       setEmail(response.email);
       setStatus('success');
-    } catch (err: any) {
-      setError(err.message ?? '再送に失敗しました');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '再送に失敗しました');
       setStatus('error');
     }
   };

--- a/frontend/src/pages/StaffFacilitySetup.tsx
+++ b/frontend/src/pages/StaffFacilitySetup.tsx
@@ -1,0 +1,28 @@
+import { FacilitySetupForm } from '../components/staff/FacilitySetupForm';
+import '../styles/signup.css';
+
+export const StaffFacilitySetup = () => {
+  return (
+    <div className="signup-wrapper">
+      <div className="container-fluid px-0">
+        <div className="row g-0 min-vh-100">
+          <div className="col-lg-6 signup-hero d-flex">
+            <div className="signup-hero-content">
+              <h2 className="fw-bold display-6 mb-3">
+                はじめの施設情報を、
+                <br />
+                正しく登録する。
+              </h2>
+              <p className="text-white-50 mb-0">
+                この情報は管理者アカウントに紐づく最初の施設として保存されます。
+              </p>
+            </div>
+          </div>
+          <div className="col-lg-6 signup-right d-flex align-items-center justify-content-center py-4">
+            <FacilitySetupForm />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/StaffLogin.tsx
+++ b/frontend/src/pages/StaffLogin.tsx
@@ -1,0 +1,28 @@
+import { StaffLoginForm } from '../components/staff/StaffLoginForm';
+import '../styles/signup.css';
+
+export const StaffLogin = () => {
+  return (
+    <div className="signup-wrapper">
+      <div className="container-fluid px-0">
+        <div className="row g-0 min-vh-100">
+          <div className="col-lg-6 signup-hero d-flex">
+            <div className="signup-hero-content">
+              <h2 className="fw-bold display-6 mb-3">
+                運営の起点を、
+                <br />
+                ここから整える。
+              </h2>
+              <p className="text-white-50 mb-0">
+                ログイン後、施設未設定の管理者はそのまま施設作成フローへ進めます。
+              </p>
+            </div>
+          </div>
+          <div className="col-lg-6 signup-right d-flex align-items-center justify-content-center py-4">
+            <StaffLoginForm />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
# Pull Request

## 📋 概要
管理者スタッフがログインした直後、およびログイン済みで再訪した際に `facility_id` 未設定であれば施設セットアップ画面へ遷移する導線を追加しました。あわせて Devise の JSON セッション API、現在のスタッフ取得 API、初回施設作成 API を実装しています。

## 🔗 関連Issue
- なし

## 📝 変更内容
- [x] Devise の staff セッションを JSON で有効化し、ログインレスポンスと `GET /api/v1/staffs/me` で `needs_facility_setup` を返すように変更
- [x] 管理者かつ施設未紐づけ時のみ施設を作成して自分に紐づける API を service + transaction で追加
- [x] `/staff/login` と `/staff/facility/setup`、フロントの API/hooks/route guard を追加し、ログイン直後と再訪時の遷移を実装

## やらないこと
- 一般 `staff` ロールの未紐づけ時導線の追加
- 施設情報編集や複数施設運用の導入
- 既存ホーム画面の大きな改修

## 📱 スクリーンショット（UI変更がある場合）
### Before
- `/staff/login` ルートなし
- 施設未設定管理者向けのセットアップ画面なし

### After
- `/staff/login` からログイン可能
- 管理者かつ `facility_id` 未設定時は `/staff/facility/setup` へ遷移

## 🧪 テスト実施項目
- `docker-compose exec api env RAILS_ENV=test bundle exec rspec spec/requests/staff_auth_spec.rb spec/requests/staff_facility_setup_spec.rb`
- `npm run lint`
- `docker-compose exec frontend npm run build`

## ⚠️ 注意事項
- [ ] マイグレーションファイルが含まれている
- [ ] 環境変数の追加/変更がある
- [x] APIの仕様変更がある
- [ ] 破壊的変更が含まれている
- [ ] パフォーマンスに影響する可能性がある

## 📋 レビューのポイント
- `needs_facility_setup` の判定がログイン時と `/staffs/me` で一貫しているか
- 施設作成 API が管理者初回のみ許可され、既存施設あり・非管理者を正しく拒否しているか
- フロントの route guard がログイン直後だけでなくページ再読み込み時にも期待どおり動くか

---

## ✅ PR作成者チェックリスト
- [x] 適切なブランチから作成されている（feature/*, bugfix/*）
- [x] コミットメッセージが規約に従っている
- [x] コードレビューの準備ができている
- [x] テストが通ることを確認済み
- [x] ドキュメントの更新が必要な場合は実施済み
